### PR TITLE
feat!: @key selection logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v2.0.0] - 2022-11-22
 
-### TBA
+### Breaking
+
+- @key directive selection in schema generation now picks the first directive
+  where fields doesn't specify a nested complex key.
+
+### Fix
+
+- Fix applied to when entities are specified in a nested complex key field, they
+  were generated as non-entity types in the Froid schema.
+- Fix issue where non-resolvable entity references in Federation 2 were
+  processed during Froid schema generation
+
+## [v1.1.0] - 2022-11-22
+
+### Fix
+
+- Support enum generation specified as @key fields.
+
+## [Unreleased]
 
 ## [v1.0.1] - 2022-10-10
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wayfair/node-froid",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Federated GQL Relay Object Identification implementation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/schema/__tests__/generateFroidSchema.fed-v2.test.ts
+++ b/src/schema/__tests__/generateFroidSchema.fed-v2.test.ts
@@ -360,6 +360,10 @@ describe('generateFroidSchema for federation v2', () => {
         text: String!
         complete: Boolean!
       }
+
+      type User @key(fields: "userId", resolvable: false) {
+        userId: String!
+      }
     `;
     const relaySchema = gql`
       directive @tag(

--- a/src/schema/generateFroidSchema.ts
+++ b/src/schema/generateFroidSchema.ts
@@ -208,7 +208,7 @@ function getKeyFields(
  *
  * @param {ObjectTypeDefinitionNode[]} definitionNodes - All definition nodes in the schema
  * @param {FederationVersion} federationVersion - The version of federation to generate schema for
- * @param {Record<string, ObjectTypeNode>} objectTypes - Something here
+ * @param {Record<string, ObjectTypeNode>} objectTypes - The generated relay entities
  * @param {FieldDefinitionNode[]} fields - The fields
  * @param {KeyMappingRecord} keyMapping - The list of key fields for the node
  * @returns {FieldDefinitionNode[]} A list field definitions
@@ -223,8 +223,9 @@ function generateComplexKeyObjectTypes(
   return Object.keys(keyMapping).flatMap((key) => {
     if (keyMapping[key]) {
       const currentField = fields.find((field) => field.name.value === key);
+      const fieldType = extractFieldType(currentField);
       const currentNode = definitionNodes.find(
-        (node) => node.name.value === extractFieldType(currentField)
+        (node) => node.name.value === fieldType
       );
 
       if (!currentNode) {
@@ -237,14 +238,16 @@ function generateComplexKeyObjectTypes(
         federationVersion
       );
 
-      objectTypes[currentNode.name.value] = {
-        kind:
-          federationVersion === FederationVersion.V1
-            ? Kind.OBJECT_TYPE_EXTENSION
-            : Kind.OBJECT_TYPE_DEFINITION,
-        name: currentNode.name,
-        fields: subKeyFields,
-      };
+      if (!objectTypes.hasOwnProperty(fieldType)) {
+        objectTypes[currentNode.name.value] = {
+          kind:
+            federationVersion === FederationVersion.V1
+              ? Kind.OBJECT_TYPE_EXTENSION
+              : Kind.OBJECT_TYPE_DEFINITION,
+          name: currentNode.name,
+          fields: subKeyFields,
+        };
+      }
 
       generateComplexKeyObjectTypes(
         definitionNodes,

--- a/src/schema/generateFroidSchema.ts
+++ b/src/schema/generateFroidSchema.ts
@@ -239,7 +239,7 @@ function generateComplexKeyObjectTypes(
       );
 
       if (!objectTypes.hasOwnProperty(fieldType)) {
-        objectTypes[currentNode.name.value] = {
+        objectTypes[fieldType] = {
           kind:
             federationVersion === FederationVersion.V1
               ? Kind.OBJECT_TYPE_EXTENSION

--- a/src/schema/generateFroidSchema.ts
+++ b/src/schema/generateFroidSchema.ts
@@ -92,7 +92,9 @@ function selectValidKeyDirective(
     .filter(Boolean)
     .map((strNode) => strNode.value)
     // Protect against people using the `id` field as an entity key
-    .filter((keys) => keys !== ID_FIELD_NAME)[0];
+    .filter((keys) => keys !== ID_FIELD_NAME)
+    .sort((a, b) => a.indexOf('{') - b.indexOf('{'))
+    .find((f) => f);
 
   if (!firstValidKeyDirectiveFields) {
     return;


### PR DESCRIPTION
## Description

* **BREAKING CHANGE**: To simplify the output schema, @key selection now picks the first directive where fields doesn't specify a nested complex key.
* Fix: When entities are specified in a nested complex key field, they were generated as non-entity types in the froid schema. 
* Fix: Non-resolvable entity references in Federation 2 are not processed during froid schema generation. i.e. @key directives with [resolvable](https://www.apollographql.com/docs/federation/federated-types/federated-directives/#resolvable) set to true will be ignored to prevent extending entity references
## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [x] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/wayfair-incubator/node-froid/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
