### PR TITLE
Omit interface objects from node relay schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.1.0] - 2023-06-01
+
+### Added
+
+- Omit `@interfaceObject`s prior to generating node-relay schema to avoid breaking federation composition
 ## [v2.0.1] - 2022-11-22
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to
 
 ### Added
 
-- Omit `@interfaceObject`s prior to generating node-relay schema to avoid breaking federation composition
+- Omit `@interfaceObject`s prior to generating node-relay schema to avoid
+  breaking federation composition
 
 ## [v2.0.1] - 2022-11-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added
 
 - Omit `@interfaceObject`s prior to generating node-relay schema to avoid breaking federation composition
+
 ## [v2.0.1] - 2022-11-22
 
 ### Fix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wayfair/node-froid",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Federated GQL Relay Object Identification implementation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/schema/__tests__/removeInterfaceObjects.test.ts
+++ b/src/schema/__tests__/removeInterfaceObjects.test.ts
@@ -1,0 +1,93 @@
+import {testGql as gql} from '../../__tests__/helpers';
+import {Kind, parse, print} from 'graphql';
+import {removeInterfaceObjects} from '../removeInterfaceObjects';
+import {ObjectTypeNode} from '../types';
+
+describe('removeInterfaceObject', () => {
+  it('removes ObjectTypeDefinitions with @interfaceObject', () => {
+    const schema = gql`
+      type Foo {
+        fooId: String
+      }
+
+      type Media @key(fields: "authorId") @interfaceObject {
+        authorId: String
+        rating: String
+      }
+    `;
+
+    const input = parse(schema).definitions as ObjectTypeNode[];
+
+    const output = removeInterfaceObjects(input);
+
+    const expectedOutput = gql`
+      type Foo {
+        fooId: String
+      }
+    `;
+
+    expect(print({kind: Kind.DOCUMENT, definitions: output})).toEqual(
+      print(parse(expectedOutput))
+    );
+  });
+
+  it('removes ObjectTypeExtensions with @interfaceObject and removes the corresponding ObjectTypeDefinition', () => {
+    const schema = gql`
+      type Bar {
+        barId: String
+      }
+
+      type Container @key(fields: "manufacturerId") {
+        manufacturerId: String
+      }
+
+      extend type Container @interfaceObject {
+        weight: Float
+      }
+    `;
+
+    const input = parse(schema).definitions as ObjectTypeNode[];
+
+    const output = removeInterfaceObjects(input);
+
+    const expectedOutput = gql`
+      type Bar {
+        barId: String
+      }
+    `;
+
+    expect(print({kind: Kind.DOCUMENT, definitions: output})).toEqual(
+      print(parse(expectedOutput))
+    );
+  });
+
+  it('removes Java-style ObjectTypeExtensions (ObjectTypeDefinitions with @extends) with @interfaceObject and removes the corresponding ObjectTypeDefinition', () => {
+    const schema = gql`
+      type Bar {
+        barId: String
+      }
+
+      type Container @key(fields: "manufacturerId") {
+        manufacturerId: String
+      }
+
+      type Container @interfaceObject @extends {
+        weight: Float
+      }
+    `;
+
+    const input = parse(schema).definitions as ObjectTypeNode[];
+
+    const output = removeInterfaceObjects(input);
+
+    const expectedOutput = gql`
+      type Bar {
+        barId: String
+      }
+    `;
+
+    expect(print({kind: Kind.DOCUMENT, definitions: output})).toEqual(
+      print(parse(expectedOutput))
+    );
+  });
+});

--- a/src/schema/constants.ts
+++ b/src/schema/constants.ts
@@ -4,3 +4,4 @@ export const EXTERNAL_DIRECTIVE = 'external';
 export const EXTENDS_DIRECTIVE = 'extends';
 export const TAG_DIRECTIVE = 'tag';
 export const KEY_DIRECTIVE = 'key';
+export const INTERFACE_OBJECT_DIRECTIVE = 'interfaceObject';

--- a/src/schema/generateFroidSchema.ts
+++ b/src/schema/generateFroidSchema.ts
@@ -301,14 +301,16 @@ export function generateFroidSchema(
   const subgraphs = [...currentSchemaMap.values()].map((sdl) => parse(sdl));
 
   // extract all definition nodes for federated schema
-  let allDefinitionNodes = subgraphs.reduce<DefinitionNode[]>(
+  const allDefinitionNodes = subgraphs.reduce<DefinitionNode[]>(
     (accumulator, value) => accumulator.concat(value.definitions),
     []
   );
 
-  allDefinitionNodes = removeInterfaceObjects(allDefinitionNodes);
+  const filteredDefinitionNodes = removeInterfaceObjects(allDefinitionNodes);
 
-  const extensionAndDefinitionNodes = getNonRootObjectTypes(allDefinitionNodes);
+  const extensionAndDefinitionNodes = getNonRootObjectTypes(
+    filteredDefinitionNodes
+  );
   const definitionNodes = getObjectDefinitions(extensionAndDefinitionNodes);
 
   // generate list of object types we need to generate the relay schema
@@ -381,7 +383,7 @@ export function generateFroidSchema(
       tagDefinition,
       ...createCustomReturnTypes(
         Object.values(relayObjectTypes),
-        allDefinitionNodes,
+        filteredDefinitionNodes,
         federationVersion
       ),
       createQueryDefinition(allTagDirectives),

--- a/src/schema/removeInterfaceObjects.ts
+++ b/src/schema/removeInterfaceObjects.ts
@@ -1,0 +1,94 @@
+import {DefinitionNode, Kind} from 'graphql';
+import {EXTENDS_DIRECTIVE, INTERFACE_OBJECT_DIRECTIVE} from './constants';
+
+/**
+ * Checks if given node is an ObjectTypeDefinition without an @extends directive.
+ *
+ * @param node - Node to check
+ * @returns boolean - True if node is an ObjectTypeDefinition without an @extends directive, false otherwise.
+ */
+function isObjectTypeExtension(node: DefinitionNode): boolean {
+  return !!(
+    node.kind === Kind.OBJECT_TYPE_EXTENSION ||
+    (node.kind === Kind.OBJECT_TYPE_DEFINITION &&
+      node.directives?.some(
+        (directive) => directive.name.value === EXTENDS_DIRECTIVE
+      ))
+  );
+}
+
+/**
+ * Checks if given node is an ObjectTypeExtension and has @interfaceObject directive.
+ * Checks for both `extend type Foo` and Java-style `type Foo @extends` syntax
+ *
+ * @param node - Node to check
+ * @returns boolean - True if node is ObjectTypeExtension and has @interfaceObject directive, false otherwise.
+ */
+function getObjectTypeExtensionsWithInterfaceObject(
+  node: DefinitionNode
+): boolean {
+  return !!(
+    isObjectTypeExtension(node) &&
+    'directives' in node &&
+    node.directives?.some(
+      (directive) => directive.name.value === 'interfaceObject'
+    )
+  );
+}
+
+/**
+ * Removes nodes from the list that have @interfaceObject directive or their name is in extensionsWithInterfaceObject.
+ *
+ * @param nodes - Array of nodes to filter
+ * @param extensionsWithInterfaceObject - Array of names to exclude
+ * @returns DefinitionNode[] - Filtered array of nodes.
+ */
+function removeInterfaceObjectsFromNodes(
+  nodes: DefinitionNode[],
+  extensionsWithInterfaceObject: string[]
+): DefinitionNode[] {
+  return nodes.filter(
+    (node) =>
+      !(
+        ('directives' in node &&
+          node.directives?.some(
+            (directive) => directive.name.value === INTERFACE_OBJECT_DIRECTIVE
+          )) ||
+        ('name' in node &&
+          node.name &&
+          extensionsWithInterfaceObject.includes(node.name.value))
+      )
+  );
+}
+
+/**
+ * Removes all ObjectTypeDefinition and ObjectTypeExtension nodes with @interfaceObject
+ * directive.
+ *
+ * This is done because otherwise there is a type conflict in composition between
+ * node-relay subgraph and subgraphs implementing the types with @interfaceObject
+ *
+ * Concrete implementers of the interface are entities themselves, so corresponding
+ * node-relay subgraph types will still be generated for those.
+ *
+ * See https://www.apollographql.com/docs/federation/federated-types/interfaces/
+ * for more info on the use of @interfaceObject (requires Federation Spec v2.3 or
+ * higher)
+ *
+ * @param {DefinitionNode[]} nodes - Schema AST nodes
+ * @returns {DefinitionNode[]} Only nodes that are not using @interfaceObject
+ */
+export const removeInterfaceObjects = (
+  nodes: DefinitionNode[]
+): DefinitionNode[] => {
+  const objectTypeExtensionsWithInterfaceObject = nodes
+    .filter(getObjectTypeExtensionsWithInterfaceObject)
+    .flatMap((node) =>
+      'name' in node && node.name?.value ? node.name.value : []
+    );
+
+  return removeInterfaceObjectsFromNodes(
+    nodes,
+    objectTypeExtensionsWithInterfaceObject
+  );
+};


### PR DESCRIPTION
## Description

Removes all ObjectTypeDefinition and ObjectTypeExtension nodes with @interfaceObject directive prior to generating node relay schema. 

This is done because otherwise, there is a type conflict in composition between node-relay subgraph and subgraphs implementing the types with @interfaceObject

Concrete implementers of the interface are entities themselves, so corresponding node-relay subgraph types will still be generated for those.

See https://www.apollographql.com/docs/federation/federated-types/interfaces/ for more info on the use of @interfaceObject (requires Federation Spec v2.3 or
higher)

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/wayfair-incubator/node-froid/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
