### PR TITLE
feat: add support for custom node qualifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.2.0] - 2023-06-27
+
+### Added
+
+- Add support for a custom schema node qualifier when generating node-relay
+  schema so users can determine whether or not to include an entity in the
+  generated node-relay schema based on custom criteria
+
 ## [v2.1.0] - 2023-06-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -99,14 +99,15 @@ containing a relay-spec compliant `id` value.
 
 ### `generateFroidSchema`
 
-| Parameter Name             | Required | Description                                                                     | Type                    | Default                |
-| -------------------------- | -------- | ------------------------------------------------------------------------------- | ----------------------- | ---------------------- |
-| `subgraphSchemaMap`        | Yes      | A mapping of subgraph names --> subgraph SDLs used to generate the froid schema | `Map<string, string>`   |                        |
-| `froidSubgraphName`        | Yes      | The name of the relay subgraph service                                          | `string`                |                        |
-| `options`                  |          | Optional configuration for schema generation                                    | see specific properties | `{}`                   |
-| `options.contractTags`     |          | A list of supported [contract][contracts] tags                                  | `string[]`              | `[]`                   |
-| `options.federatedVersion` |          | The version of federation to generate schema for                                | `FederationVersion`     | `FederationVersion.V2` |
-| `options.typeExceptions`   |          | Types to exclude from `id` field generation                                     | `string[]`              | `[]`                   |
+| Parameter Name             | Required | Description                                                                                   | Type                                                                             | Default                |
+| -------------------------- | -------- | --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ---------------------- |
+| `subgraphSchemaMap`        | Yes      | A mapping of subgraph names --> subgraph SDLs used to generate the froid schema               | `Map<string, string>`                                                            |                        |
+| `froidSubgraphName`        | Yes      | The name of the relay subgraph service                                                        | `string`                                                                         |                        |
+| `options`                  |          | Optional configuration for schema generation                                                  | see specific properties                                                          | `{}`                   |
+| `options.contractTags`     |          | A list of supported [contract][contracts] tags                                                | `string[]`                                                                       | `[]`                   |
+| `options.federatedVersion` |          | The version of federation to generate schema for                                              | `FederationVersion`                                                              | `FederationVersion.V2` |
+| `options.typeExceptions`   |          | Types to exclude from `id` field generation                                                   | `string[]`                                                                       | `[]`                   |
+| `options.nodeQualifier`    |          | A custom function to qualify whether or not an entity should be included in node-relay schema | `(node: DefinitionNode, objectTypes: Record<string, ObjectTypeNode>) => boolean` |                        |
 
 Returns `DocumentNode[]`: The froid schema
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wayfair/node-froid",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Federated GQL Relay Object Identification implementation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/schema/generateFroidSchema.ts
+++ b/src/schema/generateFroidSchema.ts
@@ -269,6 +269,10 @@ export type GenerateRelayServiceSchemaOptions = {
   contractTags?: string[];
   federationVersion?: FederationVersion;
   typeExceptions?: string[];
+  nodeQualifier?: (
+    node: DefinitionNode,
+    objectTypes: Record<string, ObjectTypeNode>
+  ) => boolean;
 };
 
 /**
@@ -290,6 +294,7 @@ export function generateFroidSchema(
   // defaults
   const federationVersion = options?.federationVersion ?? FederationVersion.V2;
   const typeExceptions = options?.typeExceptions || [];
+  const nodeQualifier = options?.nodeQualifier || (() => true);
   const allTagDirectives: ConstDirectiveNode[] =
     options?.contractTags?.sort().map((tag) => createTagDirective(tag)) || [];
 
@@ -323,8 +328,9 @@ export function generateFroidSchema(
         const isException = typeExceptions.some(
           (exception) => node.name.value === exception
         );
+        const passesNodeQualifier = Boolean(nodeQualifier(node, objectTypes));
 
-        if (isException) {
+        if (isException || !passesNodeQualifier) {
           return objectTypes;
         }
 


### PR DESCRIPTION
## Description

This PR adds support for a custom schema node qualifier so users can use custom logic to determine whether an entity should or should not be included in the node-relay schema based on custom logic.

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the
      [contributing guidelines](https://github.com/wayfair-incubator/node-froid/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
