### PR TITLE
Fix complex key bugs and allow custom key sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to
 - In some cases, if a complex key included a nested entity but was not using the
   entity's key, schema generation would fail to include the nested entity's key
   field(s).
-- In some cases, if an type appeared in multiple subgraphs and was being used in
+- In some cases, if a type appeared in multiple subgraphs and was being used in
   multiple complex keys but with different field selections, not all fields
   would be included in the generated schema.
 - When generating Federation v1 schema, value types would erroneously receive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v3.0.0] - 2023-08-16
+
+### Breaking
+
+- The federation version is no longer provided as an enum value. It must now be
+  provided as a string of either `v1` or a valid `v2.x` version (examples:
+  `v2.1`, `v2.3`, etc.).
+- Fixes to complex key schema generation and federation v1 value type schema
+  generation could effect the generated schema. Please carefully compare schema
+  generated with the previous version against schema generated after upgrading.
+
+### Added
+
+- Added support for a custom key sorter. This allows for a custom key preference
+  to be applied prior to selecting the first key.
+- Added support for explicitly defining the federation version, either `v1` or a
+  valid `v2.x` version (examples: `v2.1`, `v2.3`, etc.)
+
+### Fix
+
+- In some cases, if a complex key included a nested entity but was not using the
+  entity's key, schema generation would fail to include the nested entity's key
+  field(s).
+- In some cases, if an type appeared in multiple subgraphs and was being used in
+  multiple complex keys but with different field selections, not all fields
+  would be included in the generated schema.
+- When generating Federation v1 schema, value types would erroneously receive
+  the `extend` keyword and their fields would erroneously receive the
+  `@external` directive.
+
 ## [v2.2.0] - 2023-06-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wayfair/node-froid",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "Federated GQL Relay Object Identification implementation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/schema/__tests__/generateFroidSchema.fed-v1.test.ts
+++ b/src/schema/__tests__/generateFroidSchema.fed-v1.test.ts
@@ -1,29 +1,68 @@
-import {generateFroidSchema, FederationVersion} from '../generateFroidSchema';
+import {generateFroidSchema} from '../generateFroidSchema';
 import {print, Kind, DefinitionNode} from 'graphql';
 import {stripIndent as gql} from 'common-tags';
 import {ObjectTypeNode} from '../types';
 
-function generateSchema(
-  subgraphs: Map<string, string>,
-  froidSubgraphName: string,
-  contractTags: string[] = [],
-  typeExceptions: string[] = [],
+function generateSchema({
+  subgraphs,
+  froidSubgraphName,
+  contractTags = [],
+  typeExceptions = [],
+  federationVersion = 'v1',
+  nodeQualifier,
+  keySorter,
+}: {
+  subgraphs: Map<string, string>;
+  froidSubgraphName: string;
+  contractTags?: string[];
+  typeExceptions?: string[];
+  federationVersion?: string;
   nodeQualifier?: (
     node: DefinitionNode,
     objectTypes: Record<string, ObjectTypeNode>
-  ) => boolean
-) {
+  ) => boolean;
+  keySorter?: (keys: string[], node: ObjectTypeNode) => string[];
+}) {
   return print(
     generateFroidSchema(subgraphs, froidSubgraphName, {
       contractTags,
-      federationVersion: FederationVersion.V1,
+      federationVersion,
       typeExceptions,
       nodeQualifier,
+      keySorter,
     })
   );
 }
 
 describe('generateFroidSchema for federation v1', () => {
+  it('throws an error if a custom 1.x version is provided', () => {
+    const productSchema = gql`
+      type Product @key(fields: "upc") {
+        upc: String!
+        name: String
+        price: Int
+        weight: Int
+      }
+    `;
+    const subgraphs = new Map();
+    subgraphs.set('product-subgraph', productSchema);
+
+    let errorMessage = '';
+    try {
+      generateSchema({
+        subgraphs,
+        froidSubgraphName: 'relay-subgraph',
+        federationVersion: 'v1.5',
+      });
+    } catch (err) {
+      errorMessage = err.message;
+    }
+
+    expect(errorMessage).toMatch(
+      `Federation version must be either 'v1' or a valid 'v2.x' version`
+    );
+  });
+
   it('ignores @key(fields: "id") directives', () => {
     const productSchema = gql`
       type Query {
@@ -45,7 +84,10 @@ describe('generateFroidSchema for federation v1', () => {
     const subgraphs = new Map();
     subgraphs.set('product-subgraph', productSchema);
 
-    const actual = generateSchema(subgraphs, 'relay-subgraph');
+    const actual = generateSchema({
+      subgraphs,
+      froidSubgraphName: 'relay-subgraph',
+    });
 
     expect(actual).toEqual(
       // prettier-ignore
@@ -82,7 +124,10 @@ describe('generateFroidSchema for federation v1', () => {
     const subgraphs = new Map();
     subgraphs.set('product-subgraph', productSchema);
 
-    const actual = generateSchema(subgraphs, 'relay-subgraph');
+    const actual = generateSchema({
+      subgraphs,
+      froidSubgraphName: 'relay-subgraph',
+    });
 
     expect(actual).toEqual(
       // prettier-ignore
@@ -122,7 +167,10 @@ describe('generateFroidSchema for federation v1', () => {
     const subgraphs = new Map();
     subgraphs.set('product-subgraph', productSchema);
 
-    const actual = generateSchema(subgraphs, 'relay-subgraph');
+    const actual = generateSchema({
+      subgraphs,
+      froidSubgraphName: 'relay-subgraph',
+    });
 
     expect(actual).toEqual(
       // prettier-ignore
@@ -177,7 +225,10 @@ describe('generateFroidSchema for federation v1', () => {
     const subgraphs = new Map();
     subgraphs.set('product-subgraph', productSchema);
 
-    const actual = generateSchema(subgraphs, 'relay-subgraph');
+    const actual = generateSchema({
+      subgraphs,
+      froidSubgraphName: 'relay-subgraph',
+    });
 
     expect(actual).toEqual(
       // prettier-ignore
@@ -228,7 +279,10 @@ describe('generateFroidSchema for federation v1', () => {
     const subgraphs = new Map();
     subgraphs.set('product-subgraph', productSchema);
 
-    const actual = generateSchema(subgraphs, 'relay-subgraph');
+    const actual = generateSchema({
+      subgraphs,
+      froidSubgraphName: 'relay-subgraph',
+    });
 
     expect(actual).toEqual(
       // prettier-ignore
@@ -250,13 +304,221 @@ describe('generateFroidSchema for federation v1', () => {
           brand: [Brand!]! @external
         }
 
-        extend type Brand {
-          brandId: Int! @external
-          store: Store @external
+        type Brand {
+          brandId: Int!
+          store: Store
         }
 
-        extend type Store {
-          storeId: Int! @external
+        type Store {
+          storeId: Int!
+        }
+      `
+    );
+  });
+
+  it('uses a custom key sorter to prefer complex keys', () => {
+    const productSchema = gql`
+      type Query {
+        topProducts(first: Int = 5): [Product]
+      }
+
+      type Product
+        @key(fields: "upc sku")
+        @key(fields: "upc sku brand { brandId store { storeId } }")
+        @key(fields: "upc")
+        @key(fields: "sku brand { brandId store { storeId } }") {
+        upc: String!
+        sku: String!
+        name: String
+        brand: [Brand!]!
+        price: Int
+        weight: Int
+      }
+
+      type Brand {
+        brandId: Int!
+        store: Store
+      }
+
+      type Store {
+        storeId: Int!
+      }
+    `;
+    const subgraphs = new Map();
+    subgraphs.set('product-subgraph', productSchema);
+
+    const actual = generateSchema({
+      subgraphs,
+      froidSubgraphName: 'relay-subgraph',
+      keySorter: (keys) => {
+        return keys.sort((a, b) => b.indexOf('{') - a.indexOf('{'));
+      },
+    });
+
+    expect(actual).toEqual(
+      // prettier-ignore
+      gql`
+        directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
+
+        type Query {
+          node(id: ID!): Node
+        }
+
+        interface Node {
+          id: ID!
+        }
+
+        extend type Product implements Node @key(fields: "upc sku brand { brandId store { storeId } }") {
+          id: ID!
+          upc: String! @external
+          sku: String! @external
+          brand: [Brand!]! @external
+        }
+
+        type Brand {
+          brandId: Int!
+          store: Store
+        }
+
+        type Store {
+          storeId: Int!
+        }
+      `
+    );
+  });
+
+  it('uses a custom key sorter to prefer the first ordinal key', () => {
+    const productSchema = gql`
+      type Query {
+        topProducts(first: Int = 5): [Product]
+      }
+
+      type Product
+        @key(fields: "upc")
+        @key(fields: "upc sku brand { brandId store { storeId } }")
+        @key(fields: "upc sku")
+        @key(fields: "sku brand { brandId store { storeId } }") {
+        upc: String!
+        sku: String!
+        name: String
+        brand: [Brand!]!
+        price: Int
+        weight: Int
+      }
+
+      type Brand {
+        brandId: Int!
+        store: Store
+      }
+
+      type Store {
+        storeId: Int!
+      }
+    `;
+    const subgraphs = new Map();
+    subgraphs.set('product-subgraph', productSchema);
+
+    const actual = generateSchema({
+      subgraphs,
+      froidSubgraphName: 'relay-subgraph',
+      keySorter: (keys) => keys,
+    });
+
+    expect(actual).toEqual(
+      // prettier-ignore
+      gql`
+        directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
+
+        type Query {
+          node(id: ID!): Node
+        }
+
+        interface Node {
+          id: ID!
+        }
+
+        extend type Product implements Node @key(fields: "upc") {
+          id: ID!
+          upc: String! @external
+        }
+      `
+    );
+  });
+
+  it('uses a custom key sorter to prefer complex keys only when the node is named "Book"', () => {
+    const productSchema = gql`
+      type Query {
+        topProducts(first: Int = 5): [Product]
+      }
+
+      type Product
+        @key(fields: "upc sku")
+        @key(fields: "upc sku brand { brandId }") {
+        upc: String!
+        sku: String!
+        name: String
+        brand: [Brand!]!
+        price: Int
+        weight: Int
+      }
+
+      type Brand {
+        brandId: Int!
+        store: Store
+      }
+
+      type Book
+        @key(fields: "bookId")
+        @key(fields: "bookId author { authorId }") {
+        bookId: String!
+        author: Author!
+      }
+
+      type Author {
+        authorId: String!
+      }
+    `;
+    const subgraphs = new Map();
+    subgraphs.set('product-subgraph', productSchema);
+
+    const actual = generateSchema({
+      subgraphs,
+      froidSubgraphName: 'relay-subgraph',
+      keySorter: (keys, node) => {
+        if (node.name.value === 'Book') {
+          return keys.sort((a, b) => b.indexOf('{') - a.indexOf('{'));
+        }
+        return keys;
+      },
+    });
+
+    expect(actual).toEqual(
+      // prettier-ignore
+      gql`
+        directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
+
+        type Query {
+          node(id: ID!): Node
+        }
+
+        interface Node {
+          id: ID!
+        }
+
+        extend type Product implements Node @key(fields: "upc sku") {
+          id: ID!
+          upc: String! @external
+          sku: String! @external
+        }
+
+        extend type Book implements Node @key(fields: "bookId author { authorId }") {
+          id: ID!
+          bookId: String! @external
+          author: Author! @external
+        }
+
+        type Author {
+          authorId: String!
         }
       `
     );
@@ -331,7 +593,10 @@ describe('generateFroidSchema for federation v1', () => {
     subgraphs.set('product-subgraph', productSchema);
     subgraphs.set('todo-subgraph', todoSchema);
 
-    const actual = generateSchema(subgraphs, 'relay-subgraph');
+    const actual = generateSchema({
+      subgraphs,
+      froidSubgraphName: 'relay-subgraph',
+    });
 
     expect(actual).toEqual(
       // prettier-ignore
@@ -388,7 +653,10 @@ describe('generateFroidSchema for federation v1', () => {
     subgraphs.set('brand-subgraph', brandSchema);
     subgraphs.set('product-subgraph', productSchema);
 
-    const actual = generateSchema(subgraphs, 'relay-subgraph');
+    const actual = generateSchema({
+      subgraphs,
+      froidSubgraphName: 'relay-subgraph',
+    });
 
     expect(actual).toEqual(
       // prettier-ignore
@@ -440,7 +708,12 @@ describe('generateFroidSchema for federation v1', () => {
     subgraphs.set('user-subgraph', userSchema);
     subgraphs.set('todo-subgraph', todoSchema);
 
-    const actual = generateSchema(subgraphs, 'relay-subgraph', [], ['Todo']);
+    const actual = generateSchema({
+      subgraphs,
+      froidSubgraphName: 'relay-subgraph',
+      contractTags: [],
+      typeExceptions: ['Todo'],
+    });
 
     expect(actual).toEqual(
       // prettier-ignore
@@ -493,13 +766,13 @@ describe('generateFroidSchema for federation v1', () => {
 
     const nodeQualifier = (node) => node.kind === Kind.OBJECT_TYPE_DEFINITION;
 
-    const actual = generateSchema(
+    const actual = generateSchema({
       subgraphs,
-      'relay-subgraph',
-      [],
-      [],
-      nodeQualifier
-    );
+      froidSubgraphName: 'relay-subgraph',
+      contractTags: [],
+      typeExceptions: [],
+      nodeQualifier,
+    });
 
     expect(actual).toEqual(
       // prettier-ignore
@@ -578,7 +851,10 @@ describe('generateFroidSchema for federation v1', () => {
     subgraphs.set('todo-subgraph', todoSchema);
     subgraphs.set('relay-subgraph', relaySchema);
 
-    const actual = generateSchema(subgraphs, 'relay-subgraph');
+    const actual = generateSchema({
+      subgraphs,
+      froidSubgraphName: 'relay-subgraph',
+    });
 
     expect(actual).toEqual(
       // prettier-ignore
@@ -638,7 +914,10 @@ describe('generateFroidSchema for federation v1', () => {
     subgraphs.set('user-subgraph', userSchema);
     subgraphs.set('todo-subgraph', todoSchema);
 
-    const actual = generateSchema(subgraphs, 'relay-subgraph');
+    const actual = generateSchema({
+      subgraphs,
+      froidSubgraphName: 'relay-subgraph',
+    });
 
     expect(actual).toEqual(
       // prettier-ignore
@@ -690,10 +969,11 @@ describe('generateFroidSchema for federation v1', () => {
       const subgraphs = new Map();
       subgraphs.set('product-subgraph', productSchema);
 
-      const actual = generateSchema(subgraphs, 'relay-subgraph', [
-        'storefront',
-        'supplier',
-      ]);
+      const actual = generateSchema({
+        subgraphs,
+        froidSubgraphName: 'relay-subgraph',
+        contractTags: ['storefront', 'supplier'],
+      });
 
       expect(actual).toEqual(
         // prettier-ignore
@@ -732,10 +1012,11 @@ describe('generateFroidSchema for federation v1', () => {
       const subgraphs = new Map();
       subgraphs.set('product-subgraph', productSchema);
 
-      const actual = generateSchema(subgraphs, 'relay-subgraph', [
-        'storefront',
-        'supplier',
-      ]);
+      const actual = generateSchema({
+        subgraphs,
+        froidSubgraphName: 'relay-subgraph',
+        contractTags: ['storefront', 'supplier'],
+      });
 
       expect(actual).toEqual(
         // prettier-ignore
@@ -804,10 +1085,11 @@ describe('generateFroidSchema for federation v1', () => {
       subgraphs.set('product-subgraph', productSchema);
       subgraphs.set('todo-subgraph', todoSchema);
 
-      const actual = generateSchema(subgraphs, 'relay-subgraph', [
-        'storefront',
-        'supplier',
-      ]);
+      const actual = generateSchema({
+        subgraphs,
+        froidSubgraphName: 'relay-subgraph',
+        contractTags: ['storefront', 'supplier'],
+      });
 
       expect(actual).toEqual(
         // prettier-ignore
@@ -888,10 +1170,11 @@ describe('generateFroidSchema for federation v1', () => {
       subgraphs.set('user-subgraph', userSchema);
       subgraphs.set('todo-subgraph', todoSchema);
 
-      const actual = generateSchema(subgraphs, 'relay-subgraph', [
-        'storefront',
-        'internal',
-      ]);
+      const actual = generateSchema({
+        subgraphs,
+        froidSubgraphName: 'relay-subgraph',
+        contractTags: ['storefront', 'internal'],
+      });
 
       expect(actual).toEqual(
         // prettier-ignore
@@ -927,6 +1210,113 @@ describe('generateFroidSchema for federation v1', () => {
           id: ID!
           todoId: Int! @external
           customField: UsedCustomScalar1 @external
+        }
+      `
+      );
+    });
+  });
+
+  describe('when generating schema for complex keys', () => {
+    it('finds the complete schema cross-subgraph', () => {
+      const magazineSchema = gql`
+        type Magazine
+          @key(fields: "magazineId publisher { address { country } }") {
+          magazineId: String!
+          publisher: Publisher!
+        }
+
+        type Publisher {
+          address: Address!
+        }
+
+        type Address {
+          country: String!
+        }
+      `;
+
+      const bookSchema = gql`
+        type Book
+          @key(fields: "bookId author { fullName address { postalCode } }") {
+          bookId: String!
+          title: String!
+          author: Author!
+        }
+
+        extend type Author @key(fields: "authorId") {
+          authorId: Int! @external
+          fullName: String! @external
+          address: Address! @external
+        }
+
+        type Address {
+          postalCode: String!
+          country: String!
+        }
+      `;
+
+      const authorSchema = gql`
+        type Author @key(fields: "authorId") {
+          authorId: Int!
+          fullName: String!
+          address: Address!
+        }
+
+        type Address {
+          postalCode: String!
+          country: String!
+        }
+      `;
+
+      const subgraphs = new Map();
+      subgraphs.set('magazine-subgraph', magazineSchema);
+      subgraphs.set('book-subgraph', bookSchema);
+      subgraphs.set('author-subgraph', authorSchema);
+
+      const actual = generateSchema({
+        subgraphs,
+        froidSubgraphName: 'relay-subgraph',
+        contractTags: ['storefront', 'internal'],
+      });
+
+      expect(actual).toEqual(
+        // prettier-ignore
+        gql`
+        directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
+
+        type Query {
+          node(id: ID!): Node @tag(name: "internal") @tag(name: "storefront")
+        }
+
+        interface Node @tag(name: "internal") @tag(name: "storefront") {
+          id: ID!
+        }
+
+        extend type Magazine implements Node @key(fields: "magazineId publisher { address { country } }") {
+          id: ID!
+          magazineId: String! @external
+          publisher: Publisher! @external
+        }
+
+        type Publisher {
+          address: Address!
+        }
+
+        type Address {
+          country: String!
+          postalCode: String!
+        }
+
+        extend type Book implements Node @key(fields: "bookId author { fullName address { postalCode } }") {
+          id: ID!
+          bookId: String! @external
+          author: Author! @external
+        }
+
+        extend type Author implements Node @key(fields: "authorId") {
+          id: ID!
+          fullName: String! @external
+          address: Address! @external
+          authorId: Int! @external
         }
       `
       );

--- a/src/schema/constants.ts
+++ b/src/schema/constants.ts
@@ -1,3 +1,6 @@
+export const FED1_VERSION = 'v1';
+export const FED2_DEFAULT_VERSION = 'v2.0';
+export const FED2_VERSION_PREFIX = 'v2.';
 export const ID_FIELD_NAME = 'id';
 export const ID_FIELD_TYPE = 'ID';
 export const EXTERNAL_DIRECTIVE = 'external';

--- a/src/schema/createLinkSchemaExtension.ts
+++ b/src/schema/createLinkSchemaExtension.ts
@@ -1,10 +1,11 @@
 import {ConstArgumentNode, Kind, SchemaExtensionNode} from 'graphql';
+import {FED2_DEFAULT_VERSION} from './constants';
 
-export const FED2_OPT_IN_URL = 'https://specs.apollo.dev/federation/v2.0';
+export const FED2_OPT_IN_URL = 'https://specs.apollo.dev/federation/';
 
 export const createLinkSchemaExtension = (
   imports: string[] = ['@key'],
-  url = FED2_OPT_IN_URL
+  version = FED2_DEFAULT_VERSION
 ): SchemaExtensionNode => {
   if (!imports.length) {
     throw new Error('At least one import must be provided.');
@@ -19,7 +20,7 @@ export const createLinkSchemaExtension = (
       },
       value: {
         kind: Kind.STRING,
-        value: url,
+        value: FED2_OPT_IN_URL + version,
       },
     },
     {

--- a/src/schema/generateFroidSchema.ts
+++ b/src/schema/generateFroidSchema.ts
@@ -266,7 +266,9 @@ function generateComplexKeyObjectTypes(
         currentNodes,
         keyMapping[key] || {},
         federationVersion
-      ).filter((field) =>
+      );
+
+      const deduplicatedSubKeyFields = subKeyFields.filter((field) =>
         existingFields.every(
           (existingField) => existingField.name.value !== field.name.value
         )
@@ -278,7 +280,7 @@ function generateComplexKeyObjectTypes(
             ? Kind.OBJECT_TYPE_EXTENSION
             : Kind.OBJECT_TYPE_DEFINITION,
         name: currentNode.name,
-        fields: [...existingFields, ...subKeyFields],
+        fields: [...existingFields, ...deduplicatedSubKeyFields],
         ...existingDirectives,
         ...existingInterfaces,
       };

--- a/src/schema/generateFroidSchema.ts
+++ b/src/schema/generateFroidSchema.ts
@@ -10,10 +10,13 @@ import {
   parse,
 } from 'graphql';
 import {
+  FED2_DEFAULT_VERSION,
   ID_FIELD_NAME,
   EXTENDS_DIRECTIVE,
   KEY_DIRECTIVE,
   TAG_DIRECTIVE,
+  FED1_VERSION,
+  FED2_VERSION_PREFIX,
 } from './constants';
 import {implementsNodeInterface, externalDirective} from './astDefinitions';
 import {isRootType} from './isRootType';
@@ -27,6 +30,19 @@ import {createLinkSchemaExtension} from './createLinkSchemaExtension';
 import {createFederationV1TagDirectiveDefinition} from './createFederationV1TagDirectiveDefinition';
 import {ObjectTypeNode, KeyMappingRecord, ValidKeyDirective} from './types';
 import {removeInterfaceObjects} from './removeInterfaceObjects';
+
+type KeySorter = (keys: string[], node: ObjectTypeNode) => string[];
+
+const isEntity = (nodes: ObjectTypeNode[]): boolean =>
+  nodes.some((node) =>
+    node?.directives?.some(
+      (directive) => directive.name.value === KEY_DIRECTIVE
+    )
+  );
+
+const defaultKeySorter: KeySorter = (keys: string[]): string[] => {
+  return keys.sort((a, b) => a.indexOf('{') - b.indexOf('{'));
+};
 
 /**
  * Returns all non-root types and extended types
@@ -72,10 +88,12 @@ function getObjectDefinitions(
  * Returns all non-extended types with explicit ownership to a single subgraph
  *
  * @param {ObjectTypeDefinitionNode} node - The node to process `@key` directives for
+ * @param keySorter
  * @returns {ValidKeyDirective} The matching directive to use for generating the Global Object Identifier
  */
 function selectValidKeyDirective(
-  node: ObjectTypeDefinitionNode
+  node: ObjectTypeDefinitionNode,
+  keySorter: KeySorter
 ): ValidKeyDirective | undefined {
   const keyDirectives = node.directives?.filter(
     (directive) => directive.name.value === KEY_DIRECTIVE
@@ -85,17 +103,18 @@ function selectValidKeyDirective(
     return;
   }
 
-  // get field names that are @key to the entity
-  const firstValidKeyDirectiveFields = keyDirectives
+  // Prep the key directives for selection
+  const keys = keyDirectives
     .map((directive) => directive.arguments)
     .flat()
     .map((arg) => arg?.value as StringValueNode)
     .filter(Boolean)
     .map((strNode) => strNode.value)
     // Protect against people using the `id` field as an entity key
-    .filter((keys) => keys !== ID_FIELD_NAME)
-    .sort((a, b) => a.indexOf('{') - b.indexOf('{'))
-    .find((f) => f);
+    .filter((keys) => keys !== ID_FIELD_NAME);
+
+  // get field names that are @key to the entity
+  const firstValidKeyDirectiveFields = keySorter(keys, node).find((f) => f);
 
   if (!firstValidKeyDirectiveFields) {
     return;
@@ -173,33 +192,34 @@ function getTagDirectivesForIdField(
  * Generates key field nodes
  * Includes `@external` directive for Federation V1 generation
  *
- * @param {ObjectTypeDefinitionNode} node - The node to decorate
+ * @param {ObjectTypeDefinitionNode[]} nodes - The node to decorate
  * @param {KeyMappingRecord} keyMappingRecord - The list of key fields for the node
  * @param {FederationVersion} federationVersion - The version of federation to generate schema for
  * @returns {FieldDefinitionNode[]} A list field definitions
  */
 function getKeyFields(
-  node: ObjectTypeNode,
+  nodes: ObjectTypeNode[],
   keyMappingRecord: KeyMappingRecord,
   federationVersion: FederationVersion
 ): FieldDefinitionNode[] {
+  const nodeIsEntity = isEntity(nodes);
   const keyFieldNames = Object.keys(keyMappingRecord);
-
-  return (
-    node.fields
-      // take only @key fields and add @external directive to each of these
-      ?.filter((field) => keyFieldNames.includes(field.name.value))
-      .map(
-        (field): FieldDefinitionNode => ({
-          ...field,
-          description: undefined,
-          directives:
-            federationVersion === FederationVersion.V1
-              ? [externalDirective]
-              : [],
-        })
-      ) || []
-  );
+  const allfields = nodes.flatMap((node) => node.fields || []);
+  return (keyFieldNames
+    .map((keyFieldName) => {
+      const matchingField = allfields.find(
+        (field) => field.name.value === keyFieldName
+      );
+      return {
+        ...matchingField,
+        description: undefined,
+        directives:
+          federationVersion === FederationVersion.V1 && nodeIsEntity
+            ? [externalDirective]
+            : [],
+      };
+    })
+    .filter(Boolean) || []) as FieldDefinitionNode[];
 }
 
 /**
@@ -224,30 +244,44 @@ function generateComplexKeyObjectTypes(
     if (keyMapping[key]) {
       const currentField = fields.find((field) => field.name.value === key);
       const fieldType = extractFieldType(currentField);
-      const currentNode = definitionNodes.find(
-        (node) => node.name.value === fieldType
-      );
+      const currentNodes =
+        definitionNodes.filter((node) => node.name.value === fieldType) || [];
+      const currentNode = currentNodes[0];
 
-      if (!currentNode) {
+      if (!currentNodes.length) {
         return;
       }
 
+      const nodeIsEntity = isEntity(currentNodes);
+      const existingNode = objectTypes[fieldType];
+      const existingFields = existingNode?.fields || [];
+      const existingDirectives = existingNode?.directives
+        ? {directives: existingNode.directives}
+        : {};
+      const existingInterfaces = existingNode?.interfaces
+        ? {interfaces: existingNode.interfaces}
+        : {};
+
       const subKeyFields = getKeyFields(
-        currentNode,
+        currentNodes,
         keyMapping[key] || {},
         federationVersion
+      ).filter((field) =>
+        existingFields.every(
+          (existingField) => existingField.name.value !== field.name.value
+        )
       );
 
-      if (!objectTypes.hasOwnProperty(fieldType)) {
-        objectTypes[fieldType] = {
-          kind:
-            federationVersion === FederationVersion.V1
-              ? Kind.OBJECT_TYPE_EXTENSION
-              : Kind.OBJECT_TYPE_DEFINITION,
-          name: currentNode.name,
-          fields: subKeyFields,
-        };
-      }
+      objectTypes[fieldType] = {
+        kind:
+          federationVersion === FederationVersion.V1 && nodeIsEntity
+            ? Kind.OBJECT_TYPE_EXTENSION
+            : Kind.OBJECT_TYPE_DEFINITION,
+        name: currentNode.name,
+        fields: [...existingFields, ...subKeyFields],
+        ...existingDirectives,
+        ...existingInterfaces,
+      };
 
       generateComplexKeyObjectTypes(
         definitionNodes,
@@ -267,12 +301,13 @@ export enum FederationVersion {
 
 export type GenerateRelayServiceSchemaOptions = {
   contractTags?: string[];
-  federationVersion?: FederationVersion;
+  federationVersion?: string;
   typeExceptions?: string[];
   nodeQualifier?: (
     node: DefinitionNode,
     objectTypes: Record<string, ObjectTypeNode>
   ) => boolean;
+  keySorter?: KeySorter;
 };
 
 /**
@@ -292,8 +327,23 @@ export function generateFroidSchema(
   options: GenerateRelayServiceSchemaOptions = {}
 ): DocumentNode {
   // defaults
-  const federationVersion = options?.federationVersion ?? FederationVersion.V2;
+  const explicitFederationVersion =
+    options?.federationVersion ?? FED2_DEFAULT_VERSION;
+
+  if (
+    explicitFederationVersion !== FED1_VERSION &&
+    explicitFederationVersion.indexOf(FED2_VERSION_PREFIX) === -1
+  ) {
+    throw new Error(
+      `Federation version must be either '${FED1_VERSION}' or a valid '${FED2_VERSION_PREFIX}x' version. Examples: v1, v2.0, v2.3`
+    );
+  }
+  const federationVersion =
+    explicitFederationVersion === FED1_VERSION
+      ? FederationVersion.V1
+      : FederationVersion.V2;
   const typeExceptions = options?.typeExceptions || [];
+  const keySorter = options?.keySorter || defaultKeySorter;
   const nodeQualifier = options?.nodeQualifier || (() => true);
   const allTagDirectives: ConstDirectiveNode[] =
     options?.contractTags?.sort().map((tag) => createTagDirective(tag)) || [];
@@ -334,7 +384,7 @@ export function generateFroidSchema(
           return objectTypes;
         }
 
-        const validKeyDirective = selectValidKeyDirective(node);
+        const validKeyDirective = selectValidKeyDirective(node, keySorter);
 
         if (!validKeyDirective) {
           return objectTypes;
@@ -343,7 +393,7 @@ export function generateFroidSchema(
         const {keyMappingRecord, keyDirective} = validKeyDirective;
 
         const keyFields = getKeyFields(
-          node,
+          [node],
           keyMappingRecord,
           federationVersion
         );
@@ -353,15 +403,30 @@ export function generateFroidSchema(
           extensionAndDefinitionNodes
         );
 
+        const nodeIsEntity = isEntity([node]);
+        const existingNode = objectTypes[node.name.value];
+        const existingFields = (existingNode?.fields || []).filter(
+          (field) => field.name.value !== ID_FIELD_NAME
+        );
+        const dedupedKeyFields = keyFields.filter((field) =>
+          existingFields.every(
+            (existingField) => existingField.name.value !== field.name.value
+          )
+        );
+
         objectTypes[node.name.value] = {
           kind:
-            federationVersion === FederationVersion.V1
+            federationVersion === FederationVersion.V1 && nodeIsEntity
               ? Kind.OBJECT_TYPE_EXTENSION
               : Kind.OBJECT_TYPE_DEFINITION,
           name: node.name,
-          interfaces: [implementsNodeInterface],
-          directives: [keyDirective],
-          fields: [createIdField(idTagDirectives), ...keyFields],
+          interfaces: existingNode?.interfaces || [implementsNodeInterface],
+          directives: existingNode?.directives || [keyDirective],
+          fields: [
+            createIdField(idTagDirectives),
+            ...existingFields,
+            ...dedupedKeyFields,
+          ],
         };
 
         generateComplexKeyObjectTypes(
@@ -380,7 +445,10 @@ export function generateFroidSchema(
   const tagDefinition =
     federationVersion === FederationVersion.V1
       ? createFederationV1TagDirectiveDefinition()
-      : createLinkSchemaExtension(['@key', '@tag']);
+      : createLinkSchemaExtension(
+          ['@key', '@tag'],
+          explicitFederationVersion as string
+        );
 
   // build schema
   return {


### PR DESCRIPTION
## Description

### Fixes

- In some cases, a key field would attempt to copy from a type that did not include it.
- In some cases, not all fields for all keys would be copied over when they fields were part of different complex keys.
- Value types erroneously received `extend` and their fields `@external`

### Adds

- Users can now provide a custom key sorter.
- Users can now specify the federation version, either `v1` or a valid `v2.x` version (examples: `v2.1`, `v2.3`, etc.). The default is still `v2.0`.

### BREAKING CHANGE
The version is no longer supplied as an enum. It is now supplied as a string, with `v1` or a valid `v2.x` version being accepted. Additionally, changes have been made to fix complex key schema generation. Users should take care to carefully validate their generated schema after updating.

## Type of Change

- [x] Bug Fix
- [x] New Feature
- [x] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/wayfair-incubator/node-froid/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
