### PR TITLE
Consider arguments when determining id field tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v3.0.1] - 2023-08-17
+
+### Fix
+
+- Applying the `@tag` directive to an entity's `id` field could fail if the only
+  `@tag` directive in the entity was applied to a field argument. This fix now
+  considers field argument `@tag`s as well as field `@tag`s when selecting the
+  `id` field's `@tag`(s).
+
 ## [v3.0.0] - 2023-08-16
 
 ### Breaking

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wayfair/node-froid",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Federated GQL Relay Object Identification implementation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/schema/generateFroidSchema.ts
+++ b/src/schema/generateFroidSchema.ts
@@ -166,10 +166,11 @@ function getTagDirectivesForIdField(
   const tagDirectiveNames = objectNodes
     .filter((obj) => obj.name.value === node.name.value)
     .flatMap((obj) => {
-      const taggableNodes =
-        obj.fields?.flatMap((field) => [field, ...(field?.arguments || [])]) ||
-        [];
-      return taggableNodes.flatMap((field) =>
+      const taggableNodes = obj.fields?.flatMap((field) => [
+        field,
+        ...(field?.arguments || []),
+      ]);
+      return taggableNodes?.flatMap((field) =>
         field.directives
           ?.filter((directive) => directive.name.value === TAG_DIRECTIVE)
           .map(

--- a/src/schema/generateFroidSchema.ts
+++ b/src/schema/generateFroidSchema.ts
@@ -165,16 +165,19 @@ function getTagDirectivesForIdField(
 ): ConstDirectiveNode[] {
   const tagDirectiveNames = objectNodes
     .filter((obj) => obj.name.value === node.name.value)
-    .flatMap((obj) =>
-      obj.fields?.flatMap((field) =>
+    .flatMap((obj) => {
+      const taggableNodes =
+        obj.fields?.flatMap((field) => [field, ...(field?.arguments || [])]) ||
+        [];
+      return taggableNodes.flatMap((field) =>
         field.directives
           ?.filter((directive) => directive.name.value === TAG_DIRECTIVE)
           .map(
             (directive) =>
               (directive?.arguments?.[0].value as StringValueNode).value
           )
-      )
-    )
+      );
+    })
     .filter(Boolean)
     .sort() as string[];
 


### PR DESCRIPTION
## Description

### Fix

- Applying the `@tag` directive to an entity's `id` field could fail if the only
  `@tag` directive in the entity was applied to a field argument. This fix now
  considers field argument `@tag`s as well as field `@tag`s when selecting the
  `id` field's `@tag`(s).

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/wayfair-incubator/node-froid/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
