### PR TITLE
fix: include all enum values in FROID schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v3.1.1] - 2024-02-15
+
+### Fix
+
+- The `FroidSchema` class does not include all enum values found across
+  subgraphs when enum definitions differ.
+
 ## [v3.1.0] - 2023-11-09
 
 - Added a new `FroidSchema` class to test the next version of FROID schema

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wayfair/node-froid",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Federated GQL Relay Object Identification implementation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/schema/FroidSchema.ts
+++ b/src/schema/FroidSchema.ts
@@ -476,12 +476,10 @@ export class FroidSchema {
         let finalEnumValues: readonly EnumValueDefinitionNode[] = [];
 
         // Collect the enum values from the enum that is currently being inspected,
-        // skipping any enum value with @inaccessible applied to it.
+        // omitting all applied directives.
         const enumValues = nonNativeScalarType.values?.map((enumValue) => ({
           ...enumValue,
-          directives: enumValue.directives?.filter(
-            (directive) => directive.name.value === 'inaccessible'
-          ),
+          directives: [],
         }));
 
         // Get the enum definition we've created so far if one exists

--- a/src/schema/FroidSchema.ts
+++ b/src/schema/FroidSchema.ts
@@ -5,6 +5,7 @@ import {
   DefinitionNode,
   DocumentNode,
   EnumTypeDefinitionNode,
+  EnumValueDefinitionNode,
   FieldDefinitionNode,
   InterfaceTypeDefinitionNode,
   Kind,
@@ -423,7 +424,7 @@ export class FroidSchema {
    *
    * Enum values with @inaccessible tags are stripped in Federation 2.
    *
-   * Contract @tag directives are NOt applied when generating non-native scalar
+   * Contract @tag directives are NOT applied when generating non-native scalar
    * return types in the Froid subgraph. Contract @tag directives are merged
    * during supergraph composition so Froid subgraph can rely on @tag directives
    * defined by the owning subgraph(s), UNLESS an enum value is marked @inaccessible,
@@ -450,8 +451,12 @@ export class FroidSchema {
       });
     });
 
-    // De-dupe non-native scalar return types. Any definitions of scalars and enums
-    // will work since they can be guaranteed to be consistent across subgraphs
+    // De-dupe non-native scalar return types.
+    //
+    // Any definitions of scalars and enums will work since they are
+    // consistent across subgraphs.
+    //
+    // Enums must be combined across all subgraphs since they can deviate.
     const nonNativeScalarFieldTypes = new Map<
       string,
       SupportedFroidReturnTypes
@@ -462,27 +467,59 @@ export class FroidSchema {
       ) as SupportedFroidReturnTypes[]
     ).forEach((nonNativeScalarType) => {
       const returnTypeName = nonNativeScalarType.name.value;
-      if (
-        !nonNativeScalarDefinitionNames.has(returnTypeName) ||
-        nonNativeScalarFieldTypes.has(returnTypeName)
-      ) {
+      if (!nonNativeScalarDefinitionNames.has(returnTypeName)) {
         // Don't get types that are not returned in froid schema
         return;
       }
 
       if (nonNativeScalarType.kind === Kind.ENUM_TYPE_DEFINITION) {
+        let finalEnumValues: readonly EnumValueDefinitionNode[] = [];
+
+        // Collect the enum values from the enum that is currently being inspected,
+        // skipping any enum value with @inaccessible applied to it.
         const enumValues = nonNativeScalarType.values?.map((enumValue) => ({
           ...enumValue,
           directives: enumValue.directives?.filter(
             (directive) => directive.name.value === 'inaccessible'
           ),
         }));
+
+        // Get the enum definition we've created so far if one exists
+        const existingEnum = nonNativeScalarFieldTypes.get(
+          returnTypeName
+        ) as EnumTypeDefinitionNode;
+
+        // If there are existing enum values, use them for the final enum
+        if (existingEnum?.values) {
+          finalEnumValues = existingEnum.values;
+        }
+
+        // If there are enum values associated with the enum definition
+        // we're currently inspecting, include them in the final list of
+        // enum values
+        if (enumValues) {
+          // Deduplicate enum values
+          const dedupedEnumValues = enumValues.filter(
+            (value) =>
+              !finalEnumValues.some(
+                (existingValue) => existingValue.name.value === value.name.value
+              )
+          );
+          // Update the final enum value list
+          finalEnumValues = [...finalEnumValues, ...dedupedEnumValues];
+        }
+
         nonNativeScalarFieldTypes.set(returnTypeName, {
           ...nonNativeScalarType,
-          values: enumValues,
+          values: finalEnumValues.length ? finalEnumValues : undefined,
           directives: [],
           description: undefined,
         } as EnumTypeDefinitionNode);
+        return;
+      }
+
+      if (nonNativeScalarFieldTypes.has(returnTypeName)) {
+        // Don't duplicate scalars
         return;
       }
 

--- a/src/schema/__tests__/FroidSchema.test.ts
+++ b/src/schema/__tests__/FroidSchema.test.ts
@@ -1739,7 +1739,7 @@ describe('FroidSchema class', () => {
         enum UsedEnum {
           VALUE_ONE
           VALUE_THREE
-          VALUE_TWO @inaccessible
+          VALUE_TWO
         }
 
         type User implements Node @key(fields: "customEnum1 customEnum2 customField1 customField2 userId") {


### PR DESCRIPTION
## Description

When an enum is used in a key, only one enum definition is included from one of the subgraphs (and perhaps not the owning subgraph). This means Node FROID schema will only include a partial enum definition if the enum differs across subgraphs. Here's an example:

```graphql
# Subgraph A
type Foo @key(fields: "enumField") {
  enumField: UsedEnum!
}

enum UsedEnum {
  A
}
```

```graphql
# Subgraph B
enum UsedEnum {
  B
} 
```
 
```graphql
# Node FROID schema
enum UsedEnum {
  B
}

type Foo @key(fields: "enumField") implements Node {
  id: ID!
  enumField: UsedEnum!
}
```

### Solution

For the above subgraph schema, the enum definitions should be combined so all values are present:

```graphql
# Node FROID schema
enum UsedEnum {
  A
  B
}

type Foo @key(fields: "enumField") implements Node {
  id: ID!
  enumField: UsedEnum!
}
```

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the
      [contributing guidelines](https://github.com/wayfair-incubator/node-froid/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
