### PR TITLE
Allow omitted objects to be included with a new custom qualifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v3.2.0] - 2024-03-22
+
+### Added
+
+- Added a new option for an `omittedEntityQualifier` to re-evaluate and include
+  entities that may have been erroneously omitted by the `nodeQualifier`. This
+  provided the flexibility to fix missing entities while preserving previous
+  behavior
+
 ## [v3.1.1] - 2024-02-15
 
 ### Fix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wayfair/node-froid",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Federated GQL Relay Object Identification implementation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Description

When a custom `nodeQualifier` is provided, it is possible to completely omit an entity from the FROID schema. Since this may not always be the desired behavior, this PR adds a new optional qualifier to re-evaluate omitted entities to determine if they should be included in the FROID schema. We need to do it this way because we have to build the list of _passing_ entities before we can reevaluate whether the _omitted_ entities should actually be included in the FROID schema.

The tests contributed by this PR illustrate the changes in behavior with and without the new qualifier being provided.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/wayfair-incubator/node-froid/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
