### PR TITLE
Ensure transient key dependencies are applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v3.2.1] - 2024-04-29
+
+### Fixed
+
+- Fixes a case where sub-entity keys failed to roll up properly to referencing
+  entity keys when a value type was in-between.
+
 ## [v3.2.0] - 2024-03-22
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wayfair/node-froid",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Federated GQL Relay Object Identification implementation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Description

When one entity's key references another entity's key transitively, and the object in-between is a value type, the compound key for the referenced entity is not created correctly.

## Observed result

Here's an example schema:

```graphql
type Foo @key(fields: "bar { baz { bazKey } }") {
  bar: [Bar!]!
}

type Bar {
  baz: [Baz!]!
}

type Baz @key(fields: "bazId bazKey") {
  bazId: Int!
  bazKey: String!
}
```

This is the node-froid schema that would currently be generated:

```graphql
type Bar {
  baz: [Baz!]!
}

type Baz implements Node @key(fields: "bazId bazKey") {
  "The globally unique identifier."
  id: ID!
  bazId: Int!
  bazKey: String!
}

type Foo implements Node @key(fields: "bar { __typename baz { __typename bazKey } }") {
  "The globally unique identifier."
  id: ID!
  bar: [Bar!]!
}
```

Note that `Foo` doesn't get a compound key where `Foo.bar.baz` includes the `bazId` field. This means node-froid is failing to find the transient dependency.

## Expected result

The intended schema should be:

```graphql
type Bar {
  baz: [Baz!]!
}

type Baz implements Node @key(fields: "bazId bazKey") {
  "The globally unique identifier."
  id: ID!
  bazId: Int!
  bazKey: String!
}

type Foo implements Node @key(fields: "bar { __typename baz { __typename bazKey bazId } }") {
  "The globally unique identifier."
  id: ID!
  bar: [Bar!]!
}
```

Note the `bazId` in the key.

## Cause and fix

If we add a key to `Bar` like so:

```graphql
type Foo @key(fields: "bar { baz { bazKey } }") {
  bar: [Bar!]!
}

type Bar @key(fields: "baz { bazKey }") {
  baz: [Baz!]!
}

type Baz @key(fields: "bazId bazKey") {
  bazId: Int!
  bazKey: String!
}
```

Then the transient dependency is honored:

```graphql
type Bar implements Node @key(fields: "baz { bazId bazKey }") {
  "The globally unique identifier."
  id: ID!
  baz: [Baz!]!
}

type Baz implements Node @key(fields: "bazId bazKey") {
  "The globally unique identifier."
  id: ID!
  bazId: Int!
  bazKey: String!
}

type Foo implements Node @key(fields: "bar { __typename baz { __typename bazKey bazId } }") {
  "The globally unique identifier."
  id: ID!
  bar: [Bar!]!
}
```

This points to the value type breaking the inheritance of keys. This PR solves the problem, allowing the transient key dependencies to pass through value types resulting in the desired schema:

```graphql
type Bar {
  baz: [Baz!]!
}

type Baz implements Node @key(fields: "bazId bazKey") {
  "The globally unique identifier."
  id: ID!
  bazId: Int!
  bazKey: String!
}

type Foo implements Node @key(fields: "bar { __typename baz { __typename bazKey bazId } }") {
  "The globally unique identifier."
  id: ID!
  bar: [Bar!]!
}
```

To achieve this, we calculate keys based on dependencies for value types so the transient dependencies can be determined and skip applying the keys to the value types when we output their final schema. So, essentially, all objects get keys, but we only include keys on entities in the actual schema.


## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/wayfair-incubator/node-froid/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
