### PR TITLE
Improves error messages when an empty key is generated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v3.2.2] - 2024-08-20
+
+### Fixed
+
+- Improves the error message surfaced in cases where FROID generates an empty
+  key.
+
 ## [v3.2.1] - 2024-04-29
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wayfair/node-froid",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Federated GQL Relay Object Identification implementation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/schema/__tests__/FroidSchema.test.ts
+++ b/src/schema/__tests__/FroidSchema.test.ts
@@ -3009,6 +3009,31 @@ describe('FroidSchema class', () => {
     );
   });
 
+  it('provides a helpful message when failing to stringify the FROID schema', () => {
+    const productSchema = gql`
+      type Product @key(fields: "__typename") {
+        name: String
+      }
+    `;
+    const subgraphs = new Map();
+    subgraphs.set('product-subgraph', productSchema);
+
+    let errorMessage;
+    try {
+      generateSchema({
+        subgraphs,
+        froidSubgraphName: 'relay-subgraph',
+        federationVersion: FED2_DEFAULT_VERSION,
+      });
+    } catch (error) {
+      errorMessage = error.message;
+    }
+
+    expect(errorMessage).toMatch(
+      'Failed to parse key fields "" for type "Product"'
+    );
+  });
+
   it('generates schema document AST', () => {
     const productSchema = gql`
       type Product @key(fields: "upc") {

--- a/src/schema/sortDocumentAst.ts
+++ b/src/schema/sortDocumentAst.ts
@@ -193,7 +193,11 @@ function sortChildren(node: NamedNode): NamedNode {
   }
 
   const directives = node?.directives
-    ? {directives: sortDirectives(sortKeyDirectiveFields(node.directives))}
+    ? {
+        directives: sortDirectives(
+          sortKeyDirectiveFields(node.name.value, node.directives)
+        ),
+      }
     : {};
 
   if (
@@ -254,10 +258,12 @@ function sortChildren(node: NamedNode): NamedNode {
 /**
  * Sorts the `fields` argument of any @key directives in a list of directives.
  *
+ * @param {string} typename - The typename of the node the directive belongs to
  * @param {ConstDirectiveNode[]} directives - A list of directives that may include the @key directive
  * @returns {ConstDirectiveNode[]} The list of directives after any key fields have been sorted
  */
 function sortKeyDirectiveFields(
+  typename: string,
   directives: readonly ConstDirectiveNode[]
 ): readonly ConstDirectiveNode[] {
   return directives.map((directive) => {
@@ -285,7 +291,7 @@ function sortKeyDirectiveFields(
           ...fieldsArgument,
           value: {
             ...fieldsArgument.value,
-            value: Key.getSortedSelectionSetFields(fields),
+            value: Key.getSortedSelectionSetFields(typename, fields),
           },
         },
       ],


### PR DESCRIPTION
## Description

In cases where FROID schema schema generation results in empty `@key` fields (such as when only `__typename` is used as a key), FROID would return an unhelpful message:

```
Syntax Error: Expected Name, found "}".
```

This PR catches that error and instead throws an improved error to better explain what's going on:

```
Failed to parse key fields "" for type "SomeType" due to error: Syntax Error: Expected Name, found "}". 
```

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

## Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/wayfair-incubator/node-froid/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
