### PR TITLE
fix: No partial shareable value type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v3.2.3] - 2025-09-29
+
+### Fix
+
+- The `FroidSchema` class does not include all shareable value type fields found
+  across subgraphs.
+
 ## [v3.2.2] - 2024-08-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wayfair/node-froid",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Federated GQL Relay Object Identification implementation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/schema/ObjectType.ts
+++ b/src/schema/ObjectType.ts
@@ -9,7 +9,6 @@ import {Key} from './Key';
 import {
   DirectiveName,
   EXTERNAL_DIRECTIVE_AST,
-  SHAREABLE_DIRECTIVE_AST,
 } from './constants';
 import {ObjectTypeNode} from './types';
 import {FroidSchema, KeySorter, NodeQualifier} from './FroidSchema';

--- a/src/schema/ObjectType.ts
+++ b/src/schema/ObjectType.ts
@@ -6,10 +6,7 @@ import {
   StringValueNode,
 } from 'graphql';
 import {Key} from './Key';
-import {
-  DirectiveName,
-  EXTERNAL_DIRECTIVE_AST,
-} from './constants';
+import {DirectiveName, EXTERNAL_DIRECTIVE_AST} from './constants';
 import {ObjectTypeNode} from './types';
 import {FroidSchema, KeySorter, NodeQualifier} from './FroidSchema';
 import {KeyField} from './KeyField';

--- a/src/schema/__tests__/FroidSchema.test.ts
+++ b/src/schema/__tests__/FroidSchema.test.ts
@@ -1347,6 +1347,74 @@ describe('FroidSchema class', () => {
     );
   });
 
+  it('applies the @shareable directive to types marked with @shareable and includes all fields from supergraph', () => {
+    const bookSchema = gql`
+      type Book @key(fields: "isbn") {
+        isbn: String!
+        title: String!
+        author: Author!
+      }
+
+      type Author @shareable {
+        authorId: Int!
+      }
+    `;
+
+    const authorSchema = gql`
+      type Author @shareable {
+        authorId: Int!
+        name: String!
+        email: String!
+        age: Int
+      }
+    `;
+
+    const subgraphs = new Map();
+    subgraphs.set('book-subgraph', bookSchema);
+    subgraphs.set('author-subgraph', authorSchema);
+
+    const actual = generateSchema({
+      subgraphs,
+      froidSubgraphName: 'relay-subgraph',
+      contractTags: ['storefront', 'internal'],
+      federationVersion: FED2_DEFAULT_VERSION,
+    });
+
+    expect(actual).toEqual(
+      // prettier-ignore
+      gql`
+        extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@tag", "@external", "@shareable"])
+
+        type Author @shareable {
+          age: Int
+          authorId: Int!
+          email: String!
+          name: String!
+        }
+
+        type Book implements Node @key(fields: "isbn") {
+          "The globally unique identifier."
+          id: ID!
+          isbn: String!
+        }
+
+        "The global identification interface implemented by all entities."
+        interface Node @tag(name: "internal") @tag(name: "storefront") {
+          "The globally unique identifier."
+          id: ID!
+        }
+
+        type Query {
+          "Fetches an entity by its globally unique identifier."
+          node(
+            "A globally unique entity identifier."
+            id: ID!
+          ): Node @tag(name: "internal") @tag(name: "storefront")
+        }
+      `
+    );
+  });
+
   it('uses a custom qualifier to prefer fields', () => {
     const bookSchema = gql`
       type Book @key(fields: "isbn") {

--- a/src/schema/astDefinitions.ts
+++ b/src/schema/astDefinitions.ts
@@ -1,5 +1,5 @@
 import {ConstDirectiveNode, Kind, NamedTypeNode} from 'graphql';
-import {EXTERNAL_DIRECTIVE} from './constants';
+import {EXTERNAL_DIRECTIVE, SHAREABLE_DIRECTIVE} from './constants';
 
 /**
  * Represents AST for `implements Node`
@@ -20,5 +20,16 @@ export const externalDirective: ConstDirectiveNode = {
   name: {
     kind: Kind.NAME,
     value: EXTERNAL_DIRECTIVE,
+  },
+};
+
+/**
+ * Represents AST for `@shareable` directive
+ */
+export const shareableDirective: ConstDirectiveNode = {
+  kind: Kind.DIRECTIVE,
+  name: {
+    kind: Kind.NAME,
+    value: SHAREABLE_DIRECTIVE,
   },
 };

--- a/src/schema/constants.ts
+++ b/src/schema/constants.ts
@@ -13,6 +13,7 @@ export enum Directive {
   External = '@external',
   InterfaceObject = '@interfaceObject',
   Key = '@key',
+  Shareable = '@shareable',
   Tag = '@tag',
 }
 
@@ -21,6 +22,7 @@ export enum DirectiveName {
   External = 'external',
   InterfaceObject = 'interfaceObject',
   Key = 'key',
+  Shareable = 'shareable',
   Tag = 'tag',
 }
 
@@ -34,10 +36,16 @@ export const EXTENDS_DIRECTIVE = DirectiveName.Extends;
 export const TAG_DIRECTIVE = DirectiveName.Tag;
 export const KEY_DIRECTIVE = DirectiveName.Key;
 export const INTERFACE_OBJECT_DIRECTIVE = DirectiveName.InterfaceObject;
+export const SHAREABLE_DIRECTIVE = DirectiveName.Shareable;
 
 export const EXTERNAL_DIRECTIVE_AST = {
   kind: Kind.DIRECTIVE,
   name: {kind: Kind.NAME, value: DirectiveName.External},
+} as ConstDirectiveNode;
+
+export const SHAREABLE_DIRECTIVE_AST = {
+  kind: Kind.DIRECTIVE,
+  name: {kind: Kind.NAME, value: DirectiveName.Shareable},
 } as ConstDirectiveNode;
 
 export const DEFAULT_FEDERATION_LINK_IMPORTS = [


### PR DESCRIPTION
## Description

By default, the Froid schema only includes the object type fields that are used in subgraphs. However, when shareable value type fields are not used in any subgraphs, only a portion of the shareable value type is now included in the Froid schema. 

This PR includes the following changes:

- All fields of a shareable value type are added to the Froid schema.
- All shareable fields are added to froid schema with `@external` directive
- `@shareable` directive is added for shareable value types.
- Imports `@shareable` directive. 

Example:
```graphql
# subgraph A
type Currency
  @shareable
{
  code: CurrencyCode! 
  name: String! 
  symbol: String 
}
```

```graphql
# subgraph B
type Currency
  @shareable
{
  code: CurrencyCode!  
}

type B {
currency: Currency!
}
```

```graphql
# Node friod schema
type Currency
{
  code: CurrencyCode! 
}
```

Solution:
For the above case, the node friod schema should always include all the fields of a shareable value type and have `@shareable` directive added on it
```graphql
# Node friod schema
type Currency
  @shareable
{
  code: CurrencyCode! 
  name: String! 
  symbol: String 
}
```

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the
      [contributing guidelines](https://github.com/wayfair-incubator/node-froid/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
